### PR TITLE
feat!: centralize ROR data storage for system-wide access

### DIFF
--- a/affilgood/entity_linking/constants.py
+++ b/affilgood/entity_linking/constants.py
@@ -142,6 +142,9 @@ UPDATE_OPENALEX_WORK_COUNTS_OLDER_THAN = 30
 # ROR
 ROR_URL = 'https://ror.org/'
 
+# ROR data configuration (moved from S2AFF-specific location)
+ROR_DATA_DIR = f'{EL_DATA_PATH}/ror'
+
 # If path left empty download always the latest one.
 # Name file in S2AFF/data or full path.
 ROR_DUMP_PATH = ''

--- a/affilgood/entity_linking/entity_linker.py
+++ b/affilgood/entity_linking/entity_linker.py
@@ -935,6 +935,10 @@ class EntityLinker:
                         # Use top candidate as is
                         reranked_candidates = candidates
                     else:
+                        # Get list of active linkers for this data source
+                        source_linkers = self.linkers.get(data_source, {})
+                        active_linkers = list(source_linkers.keys())
+                    
                         # Apply reranking
                         try:
                             reranked_candidates = self.reranker.rerank(
@@ -942,7 +946,8 @@ class EntityLinker:
                                 candidates,
                                 top_k=self.num_candidates_to_return,
                                 return_scores=True,
-                                data_source=data_source  # Pass data source to reranker
+                                data_source=data_source,
+                                active_linkers=active_linkers
                             )
                             
                             # Add explanation

--- a/affilgood/entity_linking/s2aff_linker.py
+++ b/affilgood/entity_linking/s2aff_linker.py
@@ -16,21 +16,39 @@ class S2AFFLinker(BaseLinker):
                 data_manager=None,
                 ror_dump_path=None,
                 return_num_candidates=NUM_CANDIDATES_TO_RETURN,
+                threshold_score=0.30,
                 debug=False,
-                rerank=True):
+                rerank=True,
+                use_cache=True,
+                data_source="ror"):
         """
         Initialize the S2AFF linker.
         
         Args:
             data_manager (DataManager, optional): Data manager instance for data operations.
             ror_dump_path (str, optional): Path to ROR dump file. If provided, will override data_manager lookup.
+            return_num_candidates (int): Number of candidates to return.
+            threshold_score (float): Minimum score threshold for candidates.
+            debug (bool): Whether to show debug output.
+            rerank (bool): Whether to apply S2AFF's internal reranking.
+            use_cache (bool): Whether to use caching.
+            data_source (str): Data source identifier (kept for compatibility, S2AFF only works with ROR).
         """
-        super().__init__()
+        if data_source != "ror":
+            if verbose:
+                print(f"S2AFF linker only supports ROR data. Processing ROR data alongside other linkers for '{data_source}'.")
+            data_source = "ror"  # Force to ROR
+        
+        # Call BaseLinker constructor with required parameters
+        super().__init__(use_cache=use_cache, data_source=data_source)
+        
         self.data_manager = data_manager
         self.ror_dump_path = ror_dump_path
         self.debug = debug
         self.rerank = rerank
         self.return_num_candidates = return_num_candidates
+        self.threshold_score = threshold_score
+        self.data_source = data_source  # Store data source (always "ror" for S2AFF)
         
         # These will be initialized later
         self.ror_index = None
@@ -52,57 +70,74 @@ class S2AFFLinker(BaseLinker):
         if self.data_manager is not None:
             self._prepare_data()
         
-        """
-        # Get the ROR dump path if not already provided
-        if not self.ror_dump_path and self.data_manager is not None:
-            self.ror_dump_path = self.data_manager.get_latest_ror()
-        
-        if not self.ror_dump_path:
-            raise FileNotFoundError("Failed to retrieve the latest ROR dump.")
-        """
-            
         # Initialize S2AFF specific components
         try:
             # Import S2AFF modules here to avoid circular imports
             # Load ROR index
-            print(f"Loading ROR index from {self.ror_dump_path}...")
+            if self.debug:
+                print(f"Loading ROR index from {self.ror_dump_path}...")
             from s2aff.ror import RORIndex
             self.ror_index = RORIndex(self.ror_dump_path)
             
             # Load pairwise model for S2AFF
             if self.rerank:
-                print(f'Getting pairwise ROR LightGBM reranker...')
+                if self.debug:
+                    print(f'Getting pairwise ROR LightGBM reranker...')
                 from s2aff.model import PairwiseRORLightGBMReranker
                 self.pairwise_model = PairwiseRORLightGBMReranker(self.ror_index)
             
             self.is_initialized = True
-            print("S2AFF linker initialized successfully")
+            if self.debug:
+                print("S2AFF linker initialized successfully")
         except Exception as e:
-            print(f"Error initializing S2AFF components: {e}")
+            if self.debug:
+                print(f"Error initializing S2AFF components: {e}")
             raise
 
     def _prepare_data(self):
         """Prepare S2AFF-specific data."""
         if self.data_manager is None:
             raise RuntimeError("Cannot prepare data: data_manager is not set")
-        # Resolve missing paths to URLs
+        
+        # Resolve missing S2AFF paths to URLs (excluding ROR data)
         self.data_manager.resolve_s2aff_paths()
-        # Ensure files exist or are downloaded
+        # Ensure S2AFF-specific files exist or are downloaded (excluding ROR data)
         self.data_manager.ensure_s2aff_files()
-        # Get or download ROR index.
+        
+        # Get ROR dump from shared location instead of S2AFF-specific location
         self.ror_dump_path = self.data_manager.get_latest_ror(self.ror_dump_path)
         if not self.ror_dump_path:
-            raise FileNotFoundError(f"Failed to get required ROR dump.")
+            raise FileNotFoundError(f"Failed to get required ROR dump from shared location.")
+        
+        if self.debug:
+            print(f"S2AFF using shared ROR dump: {self.ror_dump_path}")
+            
             
     def get_single_prediction(self, organization, num_candidates=None):
-        """Get S2AFF predictions for one input organization, returning multiple candidates."""
+        """
+        Get S2AFF predictions for one input organization, returning multiple candidates
+        in the standardized dictionary format.
+        
+        Args:
+            organization: Organization dictionary with 'main', 'suborg', 'location', etc.
+            num_candidates: Number of candidates to return
+            
+        Returns:
+            List of candidate dictionaries with standardized fields
+        """
         if num_candidates is None:
             num_candidates = self.return_num_candidates
         
+        # Ensure initialization
+        if not self.is_initialized:
+            self.initialize()
+        
+        # Build affiliation components
         affiliation = []
         suborg = organization.get('suborg', '')
         org = organization['main']
         location = organization['location']
+        
         if suborg:
             affiliation.append(suborg)
         affiliation.append(org)
@@ -111,14 +146,19 @@ class S2AFFLinker(BaseLinker):
         affiliation_string = ', '.join(affiliation)
         
         if self.debug:
-            print(f"=> Getting prediction for {affiliation_string}")
+            print(f"S2AFFLinker: Getting prediction for {affiliation_string}")
+        
+        # Create cache key with data source prefix for consistency
+        cache_key = f"{self.data_source}:{affiliation_string}"
         
         # Check cache first
-        cached_results = self._get_predictions_from_cache(affiliation_string, num_candidates)
+        cached_results, is_reranked = self._get_predictions_from_cache(cache_key, num_candidates)
         if cached_results is not None:
+            if self.debug:
+                print(f"S2AFFLinker: Returning cached results")
             return cached_results
         
-        # If not in cache, get candidates
+        # Get candidates from S2AFF
         if self.debug:
             print(f"Retrieving first-stage candidates for org: {org}, location: {location}, suborg: {[suborg]}")
         
@@ -140,21 +180,8 @@ class S2AFFLinker(BaseLinker):
         candidates_list = []
         
         if candidates:
-            # Add both raw candidates and reranked candidates based on need
-            
-            # First, get raw candidates
-            for i, (ror_idx, score) in enumerate(zip(candidates[:num_candidates], scores[:num_candidates])):
-                if ror_idx in self.ror_index.ror_dict and ROR_ID_FIELD in self.ror_index.ror_dict[ror_idx]:
-                    raw_id = self.ror_index.ror_dict[ror_idx][ROR_ID_FIELD]
-                    raw_score = score
-                    raw_name = self.ror_index.ror_dict[raw_id][ROR_NAME_FIELD] if ROR_NAME_FIELD in self.ror_index.ror_dict[raw_id] else raw_id
-                    
-                    # For combined retrieval mode, we could just return these candidates
-                    if not hasattr(self, 'rerank') or not self.rerank:
-                        candidates_list.append((raw_id, raw_name, raw_score))
-            
-            # If we want reranking and don't have enough candidates yet, get reranked ones
-            if (hasattr(self, 'rerank') and self.rerank) or not candidates_list:
+            # Apply reranking if enabled
+            if self.rerank and self.pairwise_model:
                 # Rerank candidates
                 if self.debug:
                     print(f"Retrieving re-ranked candidates for affiliation_string: {affiliation_string}, candidates: {candidates}, scores: {scores}")
@@ -167,31 +194,72 @@ class S2AFFLinker(BaseLinker):
                     reranked_candidates_with_scores = [f"{reranked_candidates[i]}:{reranked_scores[i]:.4f}" for i in range(len(reranked_candidates))]
                     print(f"Re-ranked candidates: {reranked_candidates_with_scores}")
                 
-                # Process all candidates up to num_candidates
-                candidates_list = []  # Reset if we're doing reranking
-                for i, (ror_idx, score) in enumerate(zip(reranked_candidates[:num_candidates], reranked_scores[:num_candidates])):
-                    if score >= THRESHOLD_SCORE_RERANKED_EL:
-                        if (ror_idx in self.ror_index.ror_dict and
-                            ROR_ID_FIELD in self.ror_index.ror_dict[ror_idx]):
-                            predicted_id = self.ror_index.ror_dict[ror_idx][ROR_ID_FIELD]
-                            predicted_score = score
-                            predicted_name = self.ror_index.ror_dict[predicted_id][ROR_NAME_FIELD] if ROR_NAME_FIELD in self.ror_index.ror_dict[predicted_id] else predicted_id
-                            
-                            # Add to candidates list
-                            candidates_list.append((
-                                predicted_id,
-                                predicted_name,
-                                predicted_score
-                            ))
+                # Use reranked results
+                final_candidates = reranked_candidates
+                final_scores = reranked_scores
+                score_threshold = THRESHOLD_SCORE_RERANKED_EL
+                explanation_suffix = "with S2AFF reranking"
+            else:
+                # Use first-stage results without reranking
+                final_candidates = candidates
+                final_scores = scores
+                score_threshold = THRESHOLD_SCORE_FILTER_FIRSTAGE_EL
+                explanation_suffix = "without reranking"
+            
+            # Convert to standardized dictionary format
+            for i, (ror_idx, score) in enumerate(zip(final_candidates[:num_candidates], final_scores[:num_candidates])):
+                if score >= score_threshold:
+                    if (ror_idx in self.ror_index.ror_dict and
+                        ROR_ID_FIELD in self.ror_index.ror_dict[ror_idx]):
+                        
+                        # Get organization info from ROR index
+                        ror_org = self.ror_index.ror_dict[ror_idx]
+                        predicted_id = ror_org[ROR_ID_FIELD]
+                        
+                        # Get full organization record for additional fields
+                        full_org_record = self.ror_index.ror_dict.get(predicted_id, {})
+                        predicted_name = full_org_record.get(ROR_NAME_FIELD, predicted_id)
+                        
+                        # Create standardized candidate dictionary
+                        candidate_dict = {
+                            "id": predicted_id,
+                            "name": predicted_name,
+                            "enc_score": float(score),
+                            "orig_score": float(score),  # S2AFF doesn't distinguish between these
+                            "source": "s2aff",
+                            "data_source": self.data_source,
+                            "query_org": organization,
+                            "explanation": f"Matched with S2AFF {explanation_suffix} with score {score:.4f}"
+                        }
+                        
+                        # Add additional fields if available from ROR record
+                        if 'addresses' in full_org_record and full_org_record['addresses']:
+                            address = full_org_record['addresses'][0]
+                            if 'city' in address:
+                                candidate_dict['city'] = address['city']
+                            if 'country_name' in full_org_record.get('country', {}):
+                                candidate_dict['country'] = full_org_record['country']['country_name']
+                        
+                        if 'acronyms' in full_org_record:
+                            candidate_dict['acronyms'] = full_org_record['acronyms']
+                        
+                        candidates_list.append(candidate_dict)
         
-        # If we have no results, return a single None tuple
+        # If no results, return a placeholder in the expected format
         if not candidates_list:
-            candidates_list = [(None, None, 0.0)]
+            candidates_list = [{
+                "id": None,
+                "name": None,
+                "enc_score": 0.0,
+                "orig_score": 0.0,
+                "source": "s2aff",
+                "data_source": self.data_source,
+                "query_org": organization,
+                "explanation": "No matches found or all below threshold"
+            }]
         
-        # Update cache
-        self._update_predictions_cache(affiliation_string, candidates_list)
+        # Update cache with standardized results
+        self._update_predictions_cache(cache_key, candidates_list, reranked=False)
         
         return candidates_list
-      
-
 

--- a/scripts/sample_output.txt
+++ b/scripts/sample_output.txt
@@ -1,0 +1,271 @@
+Using data sources: ['ror']
+Language preprocessing is disabled
+Initializing span identifier
+Initialized span identifier: nicolauduran45/affilgood-span-v2
+Initializing NER
+Initialized NER: nicolauduran45/affilgood-ner-multilingual-v2
+Initializing entity linkers: ['Dense'] for data sources: ['ror']
+Initializing EntityLinker with data sources: ['ror']
+Initializing linkers for data source: ror
+  Initializing linker: Dense
+Created DirectPairReranker instance with supported data sources: ['ror']
+Initializing normalizer: <affilgood.metadata_normalization.normalizer.GeoNormalizer object at 0x7f4d182c7970>
+
+=========== PROCESSING ===========
+Language preprocessing completed in 0.00s
+Identifying spans for 1 texts...
+Span identification completed in 0.17s
+Identified 1 spans
+Recognizing entities...
+Entity recognition completed in 0.01s
+Normalizing entities...
+Entity normalization completed in 0.00s
+Linking entities...
+
+Processing data source: ror
+Processing with Dense
+Saved 72 entries to cache file: /home/pablo/affilgood/affilgood/entity_linking/linker_cache/DenseLinker_ror_cache.pkl
+
+_apply_reranking: second pass: added: Roma Tre University {https://ror.org/05vf0dg29}:0.95. score 0.953125 above threshold 0.6. best_score: 0.953125
+
+_apply_reranking: second pass: added: Istituto Nazionale di Fisica Nucleare, Sezione di Roma Tre {https://ror.org/009wnjh50}:0.97. score 0.96875 above threshold 0.6. best_score: 0.96875
+Entity linking completed in 0.00s
+[
+    {
+        "raw_text": "Dipartimento di Fisica, Università di Roma Tre and Istituto Nazionale di Fisica Nucleare sezione di Roma Tre, Via Vasca Navale 84, 00146 Roma, Italy",
+        "span_entities": [
+            "Dipartimento di Fisica, Università di Roma Tre and Istituto Nazionale di Fisica Nucleare sezione di Roma Tre, Via Vasca Navale 84, 00146 Roma, Italy"
+        ],
+        "ner": [
+            {
+                "SUB": [
+                    "Dipartimento di Fisica"
+                ],
+                "ORG": [
+                    "Università di Roma Tre",
+                    "Istituto Nazionale di Fisica Nucleare sezione di Roma Tre"
+                ],
+                "ADDRESS": [
+                    "Via Vasca Navale 84"
+                ],
+                "POSTALCODE": [
+                    "00146"
+                ],
+                "CITY": [
+                    "Roma"
+                ],
+                "COUNTRY": [
+                    "Italy"
+                ]
+            }
+        ],
+        "ner_raw": [
+            [
+                {
+                    "entity_group": "SUB",
+                    "score": 0.9994518756866455,
+                    "word": "Dipartimento di Fisica",
+                    "start": 0,
+                    "end": 22
+                },
+                {
+                    "entity_group": "ORG",
+                    "score": 0.9996855854988098,
+                    "word": "Università di Roma Tre",
+                    "start": 24,
+                    "end": 46
+                },
+                {
+                    "entity_group": "ORG",
+                    "score": 0.9983338117599487,
+                    "word": "Istituto Nazionale di Fisica Nucleare sezione di Roma Tre",
+                    "start": 51,
+                    "end": 108
+                },
+                {
+                    "entity_group": "ADDRESS",
+                    "score": 0.9995071291923523,
+                    "word": "Via Vasca Navale 84",
+                    "start": 110,
+                    "end": 129
+                },
+                {
+                    "entity_group": "POSTALCODE",
+                    "score": 0.9980952739715576,
+                    "word": "00146",
+                    "start": 131,
+                    "end": 136
+                },
+                {
+                    "entity_group": "CITY",
+                    "score": 0.9983300566673279,
+                    "word": "Roma",
+                    "start": 137,
+                    "end": 141
+                },
+                {
+                    "entity_group": "COUNTRY",
+                    "score": 0.9994838237762451,
+                    "word": "Italy",
+                    "start": 143,
+                    "end": 148
+                }
+            ]
+        ],
+        "osm": [
+            {
+                "CITY": "Rome",
+                "COUNTY": "Roma Capitale",
+                "STATE": "Lazio",
+                "COUNTRY": "Italy",
+                "COORDS": "('41.8933203', '12.4829321')",
+                "OSM_ID": "41485"
+            }
+        ],
+        "entity_linking": {
+            "ror": {
+                "linked_orgs_spans": [
+                    "Roma Tre University {https://ror.org/05vf0dg29}:0.95|Istituto Nazionale di Fisica Nucleare, Sezione di Roma Tre {https://ror.org/009wnjh50}:0.97"
+                ],
+                "linked_orgs": "Roma Tre University {https://ror.org/05vf0dg29}:0.95|Istituto Nazionale di Fisica Nucleare, Sezione di Roma Tre {https://ror.org/009wnjh50}:0.97",
+                "detailed_orgs": [
+                    [
+                        {
+                            "mention": "Università di Roma Tre",
+                            "candidates_above_threshold": [
+                                {
+                                    "rank": 1,
+                                    "id": "https://ror.org/05vf0dg29",
+                                    "name": "Roma Tre University",
+                                    "location": "Rome, Italy",
+                                    "initial_retriever_score": 0.9468,
+                                    "final_retriever_score": 0.99,
+                                    "reranker_score": 0.9531,
+                                    "explanation": "Reranked from 0.9900 to 0.9531 using direct pair matching (threshold: 0.60)",
+                                    "source": "dense",
+                                    "data_source": "ror"
+                                },
+                                {
+                                    "rank": 2,
+                                    "id": "https://ror.org/009wnjh50",
+                                    "name": "Istituto Nazionale di Fisica Nucleare, Sezione di Roma Tre",
+                                    "location": "Rome, Italy",
+                                    "initial_retriever_score": 0.6176,
+                                    "final_retriever_score": 0.8884,
+                                    "reranker_score": 0.8867,
+                                    "explanation": "Reranked from 0.8884 to 0.8867 using direct pair matching",
+                                    "source": "dense",
+                                    "data_source": "ror"
+                                },
+                                {
+                                    "rank": 3,
+                                    "id": "https://ror.org/037263487",
+                                    "name": "Università degli Studi Internazionali di Roma",
+                                    "location": "Rome, Italy",
+                                    "initial_retriever_score": 150.1642,
+                                    "final_retriever_score": 0.7752,
+                                    "reranker_score": 0.582,
+                                    "explanation": "Reranked from 0.7752 to 0.5820 using direct pair matching",
+                                    "source": "whoosh",
+                                    "data_source": "ror"
+                                },
+                                {
+                                    "rank": 4,
+                                    "id": "https://ror.org/011at3t25",
+                                    "name": "European University of Rome",
+                                    "location": "Rome, Italy",
+                                    "initial_retriever_score": 0.6257,
+                                    "final_retriever_score": 0.6257,
+                                    "reranker_score": 0.582,
+                                    "explanation": "Reranked from 0.6257 to 0.5820 using direct pair matching",
+                                    "source": "dense",
+                                    "data_source": "ror"
+                                },
+                                {
+                                    "rank": 5,
+                                    "id": "https://ror.org/02p77k626",
+                                    "name": "University of Rome Tor Vergata",
+                                    "location": "Rome, Italy",
+                                    "initial_retriever_score": 0.6064,
+                                    "final_retriever_score": 0.7498,
+                                    "reranker_score": 0.4609,
+                                    "explanation": "Reranked from 0.7498 to 0.4609 using direct pair matching",
+                                    "source": "dense",
+                                    "data_source": "ror"
+                                }
+                            ]
+                        },
+                        {
+                            "mention": "Istituto Nazionale di Fisica Nucleare sezione di Roma Tre",
+                            "candidates_above_threshold": [
+                                {
+                                    "rank": 1,
+                                    "id": "https://ror.org/009wnjh50",
+                                    "name": "Istituto Nazionale di Fisica Nucleare, Sezione di Roma Tre",
+                                    "location": "Rome, Italy",
+                                    "initial_retriever_score": 0.9155,
+                                    "final_retriever_score": 0.99,
+                                    "reranker_score": 0.9688,
+                                    "explanation": "Reranked from 0.9900 to 0.9688 using direct pair matching (threshold: 0.60)",
+                                    "source": "dense",
+                                    "data_source": "ror"
+                                },
+                                {
+                                    "rank": 2,
+                                    "id": "https://ror.org/025rrx658",
+                                    "name": "Istituto Nazionale di Fisica Nucleare, Roma Tor Vergata",
+                                    "location": "Rome, Italy",
+                                    "initial_retriever_score": 0.5905,
+                                    "final_retriever_score": 0.99,
+                                    "reranker_score": 0.7539,
+                                    "explanation": "Reranked from 0.9900 to 0.7539 using direct pair matching",
+                                    "source": "dense",
+                                    "data_source": "ror"
+                                },
+                                {
+                                    "rank": 3,
+                                    "id": "https://ror.org/05eva6s33",
+                                    "name": "Istituto Nazionale di Fisica Nucleare, Sezione di Roma I",
+                                    "location": "Rome, Italy",
+                                    "initial_retriever_score": 0.6647,
+                                    "final_retriever_score": 0.99,
+                                    "reranker_score": 0.75,
+                                    "explanation": "Reranked from 0.9900 to 0.7500 using direct pair matching",
+                                    "source": "dense",
+                                    "data_source": "ror"
+                                },
+                                {
+                                    "rank": 4,
+                                    "id": "https://ror.org/005ta0471",
+                                    "name": "Istituto Nazionale di Fisica Nucleare",
+                                    "location": "Rome, Italy",
+                                    "initial_retriever_score": 0.6747,
+                                    "final_retriever_score": 0.99,
+                                    "reranker_score": 0.7461,
+                                    "explanation": "Reranked from 0.9900 to 0.7461 using direct pair matching",
+                                    "source": "dense",
+                                    "data_source": "ror"
+                                },
+                                {
+                                    "rank": 5,
+                                    "id": "https://ror.org/05vf0dg29",
+                                    "name": "Roma Tre University",
+                                    "location": "Rome, Italy",
+                                    "initial_retriever_score": 0.5741,
+                                    "final_retriever_score": 0.5741,
+                                    "reranker_score": 0.543,
+                                    "explanation": "Reranked from 0.5741 to 0.5430 using direct pair matching",
+                                    "source": "dense",
+                                    "data_source": "ror"
+                                }
+                            ]
+                        }
+                    ]
+                ]
+            }
+        },
+        "language_info": {}
+    }
+]
+==================================
+


### PR DESCRIPTION
BREAKING CHANGE: ROR dump location moved from S2AFF-specific directory to shared location

- Move ROR data from `S2AFF/data/` to `entity_linking/data/ror/`
- Enable ROR data sharing across all linkers (Dense, Whoosh, S2AFF)
- Prepare architecture for optional S2AFF installation
- Maintain S2AFF compatibility with shared ROR location